### PR TITLE
pkg: `com.android.cellbroadcastreceiver.module`

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -6930,6 +6930,15 @@
     "removal": "Expert"
   },
   {
+    "id": "com.android.cellbroadcastreceiver.module",
+    "list": "Aosp",
+    "description": "Same as com.android.cellbroadcastreceiver.\nCell broadcasting used to send emergency alerts.\nhttps://en.wikipedia.org/wiki/Cell_Broadcast.",
+    "dependencies": ["com.android.cellbroadcastreceiver"],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Expert"
+  },
+  {
     "id": "com.android.contacts",
     "list": "Aosp",
     "description": "AOSP Contacts\nSome OEMs(for example Xiaomi) use the same package name for their app.",


### PR DESCRIPTION
Adds `com.android.cellbroadcastreceiver.module`.

As seen [here](https://github.com/0x192/universal-android-debloater/pull/883).